### PR TITLE
Update libsodium to version 1.0.0 and dnscrypt-proxy to 1.4.1

### DIFF
--- a/package/dnscrypt-proxy/Makefile
+++ b/package/dnscrypt-proxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
-PKG_VERSION:=1.4.0
-PKG_RELEASE:=5.E
+PKG_VERSION:=1.4.1
+PKG_RELEASE:=6.E
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
-PKG_MD5SUM:=40b5b73f5042330b86084460d7c839c6
+PKG_MD5SUM:=f9d59b23fcad864af7db7d6304fda77f
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/package/dnscrypt-proxy/Makefile
+++ b/package/dnscrypt-proxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
-PKG_VERSION:=1.4.1
-PKG_RELEASE:=6.E
+PKG_VERSION:=1.4.3
+PKG_RELEASE:=6.F
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
-PKG_MD5SUM:=f9d59b23fcad864af7db7d6304fda77f
+PKG_MD5SUM:=2ec9829589c909ad88eb68f6642d18f6
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/package/libsodium/Makefile
+++ b/package/libsodium/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=1.E
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1.F
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.dnscrypt.org/libsodium/releases
-PKG_MD5SUM:=3093dabe4e038d09f0d150cef064b2f7
+PKG_MD5SUM:=9a221b49fba7281ceaaf5e278d0f4430
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/package/libsodium/Makefile
+++ b/package/libsodium/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=0.7.0
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1.E
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.dnscrypt.org/libsodium/releases
-PKG_MD5SUM:=b9029bf810c4b5a8acc3afec1286a36a
+PKG_MD5SUM:=3093dabe4e038d09f0d150cef064b2f7
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
libsodium 1.0.0 was released on 24-SEP-2014
dnscrypt-proxy 1.4.1 was released on 19-SEP-2014
