### PR TITLE
Update to dnscrypt-proxy 1.6.0

### DIFF
--- a/package/dnscrypt-proxy/Makefile
+++ b/package/dnscrypt-proxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=5.E
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
-PKG_MD5SUM:=40b5b73f5042330b86084460d7c839c6
+PKG_MD5SUM:=fa1dad8e487ab587be06e1cbccb9cfcc
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
DNSCRYPT-PROXY 1.4.0 is not available any more.